### PR TITLE
bump guzzlehttp/guzzle to version 7

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     },
     "require": {
         "php": ">=7.2.5",
-        "guzzlehttp/guzzle": "~6.0",
+        "guzzlehttp/guzzle": "~6.0|~7.0",
         "nesbot/carbon": "^2.14"
     },
     "autoload": {


### PR DESCRIPTION
This PR bumps guzzlehttp/guzzle to version 7 to make this package compatible with the latest version of laravel. As this package works with both versions of guzzlehttp, version 6 is still allowed for backwards compatibility.