### PR TITLE
Fixed incorrect specified return type in php-docs statement

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 .DS_Store
+.idea
 vendor/
 composer.lock

--- a/src/Alpaca.php
+++ b/src/Alpaca.php
@@ -696,7 +696,7 @@ class Alpaca
      *
      * @link https://docs.alpaca.markets/api-documentation/web-api/clock/#get-the-clock
      *
-     * @return void
+     * @return Response
      */
     public function getClock()
     {


### PR DESCRIPTION
The return type of getClock method was incorrectly specified. The method returns a "Response" object instead of "void".